### PR TITLE
Create static page with colour swatches for development

### DIFF
--- a/client/public/dev.html
+++ b/client/public/dev.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Bungee+Hairline&family=Bungee+Shade&family=Nunito:ital,wght@0,200;0,400;0,700;1,200;1,400;1,700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          colors: {
+            'dark-gray': '#313131',
+            'deep-purple': '#31121a',
+            plum: '#830f4c',
+            teal: '#016668',
+            coral: '#f38181',
+            gold: '#ffcb92',
+            meringue: '#fef9e8',
+          },
+          extend: {},
+          fontFamily: {
+            display: ['Bungee Shade', 'cursive'],
+            header: ['Bungee Hairline', 'cursive'],
+            body: ['Nunito', 'sans-serif'],
+          },
+        },
+      };
+    </script>
+    <title>StudeeCloud Dev Page</title>
+  </head>
+  <body>
+    <h1 class="font-display text-6xl text-center my-12">
+      StudeeCloud Dev Page
+    </h1>
+    <h2 class="font-header text-5xl mt-8 mb-4">Colours</h2>
+
+    <div class="w-fit border-2 border-black mx-5">
+      <div
+        class="bg-dark-gray text-meringue text-center"
+        style='width:8rem;height:4rem'
+      >
+        dark-gray
+      </div>
+      <div
+        class="bg-deep-purple text-meringue text-center"
+        style='width:8rem;height:4rem'
+      >
+        deep-purple
+      </div>
+      <div
+        class="bg-plum text-meringue text-center"
+        style='width:8rem;height:4rem'
+      >
+        plum
+      </div>
+      <div
+        class="bg-teal text-meringue text-center"
+        style='width:8rem;height:4rem'
+      >
+        teal
+      </div>
+      <div
+        class="bg-coral text-center"
+        style='width:8rem;height:4rem'
+      >
+        coral
+      </div>
+      <div
+        class="bg-gold text-center"
+        style='width:8rem;height:4rem'
+      >
+        gold
+      </div>
+      <div
+        class="bg-meringue text-center"
+        style='width:8rem;height:4rem'
+      >
+        meringue
+      </div>
+    
+  </body>
+</html>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -294,51 +294,6 @@ function App() {
         SIGN IN
       </button>
 
-      {/* COLOR PALETTE FOR DEVELOPMENT */}
-      <div className="flex w-fit border-2 border-black">
-        <div
-          className="bg-dark-gray text-meringue text-center"
-          style={{ width: '8rem', height: '4rem' }}
-        >
-          dark-gray
-        </div>
-        <div
-          className="bg-deep-purple text-meringue text-center"
-          style={{ width: '8rem', height: '4rem' }}
-        >
-          deep-purple
-        </div>
-        <div
-          className="bg-plum text-meringue text-center"
-          style={{ width: '8rem', height: '4rem' }}
-        >
-          plum
-        </div>
-        <div
-          className="bg-teal text-meringue text-center"
-          style={{ width: '8rem', height: '4rem' }}
-        >
-          teal
-        </div>
-        <div
-          className="bg-coral text-center"
-          style={{ width: '8rem', height: '4rem' }}
-        >
-          coral
-        </div>
-        <div
-          className="bg-gold text-center"
-          style={{ width: '8rem', height: '4rem' }}
-        >
-          gold
-        </div>
-        <div
-          className="bg-meringue text-center"
-          style={{ width: '8rem', height: '4rem' }}
-        >
-          meringue
-        </div>
-      </div>
       <PomodoroTimer />
     </main>
   );


### PR DESCRIPTION
I tried to get Tailwind styling to apply to `./public/dev.html` following the [Tailwind config docs](https://tailwindcss.com/docs/content-configuration), but this route was not successful. After enough attempts, I gave this up in favour of importing Tailwind via their Play CDN which is intended only for development and not production.

I suspect that something about React may be blocking this from working as intended. I wonder whether this issue arises because we're not serving static pages via an Express server or with the React Router, but I'm not confident in this interpretation.

Tailwind styling applies perfectly to the static `./public/dev.html` page so for now I think it would be best to move along rather than trying to troubleshoot this.