### PR TITLE
Removed useContext and replaced with props

### DIFF
--- a/client/src/components/PomodoroTimer.js
+++ b/client/src/components/PomodoroTimer.js
@@ -1,9 +1,7 @@
-import { useState } from "react";
+import { useState } from 'react';
 
-import Settings from "./Settings";
-import Timer from "./Timer";
-
-import SettingsContext from "./SettingsContext";
+import Settings from './Settings';
+import Timer from './Timer';
 
 export default function PomodoroTimer() {
   const [showSettings, setShowSettings] = useState(false);
@@ -12,18 +10,23 @@ export default function PomodoroTimer() {
 
   return (
     <main>
-      <SettingsContext.Provider
-        value={{
-          showSettings,
-          setShowSettings,
-          workMinutes,
-          breakMinutes,
-          setWorkMinutes,
-          setBreakMinutes,
-        }}
-      >
-        {showSettings ? <Settings /> : <Timer />}
-      </SettingsContext.Provider>
+      {showSettings ? (
+        <Settings
+          setShowSettings={setShowSettings}
+          workMinutes={workMinutes}
+          setWorkMinutes={setWorkMinutes}
+          breakMinutes={breakMinutes}
+          setBreakMinutes={setBreakMinutes}
+        />
+      ) : (
+        <Timer
+          setShowSettings={setShowSettings}
+          workMinutes={workMinutes}
+          setWorkMinutes={setWorkMinutes}
+          breakMinutes={breakMinutes}
+          setBreakMinutes={setBreakMinutes}
+        />
+      )}
     </main>
   );
 }

--- a/client/src/components/Settings.js
+++ b/client/src/components/Settings.js
@@ -2,6 +2,8 @@ import ReactSlider from 'react-slider';
 import './slider.css';
 
 export default function Settings(props) {
+  // setShowSettings is booelan
+  // workMinutes & setWorkMinutes and breakMinutes & setBreakMinutes are numbers
   const {
     setShowSettings,
     workMinutes,

--- a/client/src/components/Settings.js
+++ b/client/src/components/Settings.js
@@ -1,38 +1,41 @@
-import ReactSlider from "react-slider";
-import "./slider.css";
+import ReactSlider from 'react-slider';
+import './slider.css';
 
-import { useContext } from "react";
-import SettingsContext from "./SettingsContext";
-
-export default function Settings() {
-  const settingsInfo = useContext(SettingsContext);
+export default function Settings(props) {
+  const {
+    setShowSettings,
+    workMinutes,
+    setWorkMinutes,
+    breakMinutes,
+    setBreakMinutes,
+  } = props;
 
   return (
-    <div style={{ textAlign: "left" }}>
-      <label>work: {settingsInfo.workMinutes} </label>
+    <div style={{ textAlign: 'left' }}>
+      <label>work: {workMinutes} </label>
       <ReactSlider
-        className={"slider"}
-        thumbClassName={"thumb"}
-        trackClassName={"track"}
-        value={settingsInfo.workMinutes}
-        onChange={(newValue) => settingsInfo.setWorkMinutes(newValue)}
+        className={'slider'}
+        thumbClassName={'thumb'}
+        trackClassName={'track'}
+        value={workMinutes}
+        onChange={(newValue) => setWorkMinutes(newValue)}
         min={1}
         max={60}
       />
-      <label>break: {settingsInfo.breakMinutes} </label>
+      <label>break: {breakMinutes} </label>
       <ReactSlider
-        className={"slider break"}
-        thumbClassName={"thumb"}
-        trackClassName={"track"}
-        value={settingsInfo.breakMinutes}
-        onChange={(newValue) => settingsInfo.setBreakMinutes(newValue)}
+        className={'slider break'}
+        thumbClassName={'thumb'}
+        trackClassName={'track'}
+        value={breakMinutes}
+        onChange={(newValue) => setBreakMinutes(newValue)}
         min={1}
         max={60}
       />
-      <div style={{ textAlign: "center", marginTop: "20px" }}>
+      <div style={{ textAlign: 'center', marginTop: '20px' }}>
         <button
           className="btn btn-primary"
-          onClick={() => settingsInfo.setShowSettings(false)}
+          onClick={() => setShowSettings(false)}
         >
           Back
         </button>

--- a/client/src/components/SettingsContext.js
+++ b/client/src/components/SettingsContext.js
@@ -1,5 +1,0 @@
-import react from 'react';
-
-const SettingsContext = react.createContext({});
-
-export default SettingsContext;

--- a/client/src/components/Timer.js
+++ b/client/src/components/Timer.js
@@ -5,34 +5,29 @@ import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
 import PlayButton from './PlayButton';
 import PauseButton from './PauseButton';
 
-import { useContext, useState, useEffect } from 'react';
-import SettingsContext from './SettingsContext'; //FIXME: useContext component to be removed
+import { useState, useEffect } from 'react';
 
-export default function Timer() {
+export default function Timer(props) {
+  const { setShowSettings, workMinutes, breakMinutes } = props;
+
   const [isPaused, setIsPaused] = useState(false); //Used by pause & play buttons on timer
   const [mode, setMode] = useState('work'); // "Work" and "Play" alternate once timer reaches 0
   const [secondsLeft, setSecondsLeft] = useState(0); //Each mode has independent secondsLeft state
 
-  // FIXME: Refactor using just props (see values being passed through Provide component in PomodoroTimer file)
-  const settingsInfo = useContext(SettingsContext);
-
   // Initializes timer with "work" mode first
-  // FIXME: All settingsInfo will be replaced props
   useEffect(() => {
     function initTimer() {
-      setSecondsLeft(settingsInfo.workMinutes * 60);
+      setSecondsLeft(workMinutes * 60);
     }
     initTimer();
-  }, [settingsInfo.workMinutes]);
+  }, [workMinutes]);
 
   useEffect(() => {
     function switchMode() {
       const nextMode = mode === 'work' ? 'break' : 'work';
       setMode(nextMode);
       setSecondsLeft(
-        nextMode === 'work'
-          ? settingsInfo.workMinutes * 60
-          : settingsInfo.breakMinutes * 60
+        nextMode === 'work' ? workMinutes * 60 : breakMinutes * 60
       );
     }
 
@@ -55,19 +50,10 @@ export default function Timer() {
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [
-    isPaused,
-    secondsLeft,
-    settingsInfo.workMinutes,
-    mode,
-    settingsInfo.breakMinutes,
-  ]);
+  }, [isPaused, secondsLeft, workMinutes, mode, breakMinutes]);
 
   // Helper functions to calcuate time left in Min:Sec format
-  const totalSeconds =
-    mode === 'work'
-      ? settingsInfo.workMinutes * 60
-      : settingsInfo.breakMinutes * 60;
+  const totalSeconds = mode === 'work' ? workMinutes * 60 : breakMinutes * 60;
 
   const minutes = Math.floor(secondsLeft / 60);
   let seconds = secondsLeft % 60;
@@ -104,7 +90,7 @@ export default function Timer() {
       <div style={{ marginTop: '20px' }}>
         <button
           className="btn btn-primary"
-          onClick={() => settingsInfo.setShowSettings(true)}
+          onClick={() => setShowSettings(true)}
         >
           Settings
         </button>

--- a/client/src/components/Timer.js
+++ b/client/src/components/Timer.js
@@ -8,6 +8,8 @@ import PauseButton from './PauseButton';
 import { useState, useEffect } from 'react';
 
 export default function Timer(props) {
+  // setShowSettings is booelan
+  // workMinutes and breakMinutes are both numbers
   const { setShowSettings, workMinutes, breakMinutes } = props;
 
   const [isPaused, setIsPaused] = useState(false); //Used by pause & play buttons on timer


### PR DESCRIPTION
Refactor:
Removed useContext hook and createContext component
Implemented props passed from PomodoroTimer.js (parent file) to Settings.js and Timer.js

Reason:
useContext was initially implemented to prevent with "prop-drilling"
In reality, our app had one main parent component with two children -> not a complex hierarchy of nested components