### PR TITLE
Manually assign IDs to messages in the database

### DIFF
--- a/server/db/schema/04_create_messages.sql
+++ b/server/db/schema/04_create_messages.sql
@@ -1,6 +1,6 @@
 DROP TABLE IF EXISTS messages CASCADE;
 
 CREATE TABLE messages (
-  -- id SERIAL PRIMARY KEY,
+  id SERIAL PRIMARY KEY,
   message_text VARCHAR(255)
 );

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -2,21 +2,29 @@ const router = require('express').Router();
 
 module.exports = (db) => {
   router.get('/', (req, res) => {
-    const getMessages = "SELECT * FROM messages";
-    db.query(getMessages)
-      .then(data => {
-        console.log('message data', data);
-        res.json(data.rows);
-      })
-
+    const getMessages = 'SELECT * FROM messages';
+    db.query(getMessages).then((data) => {
+      console.log('message data', data);
+      res.json(data.rows);
+    });
   });
   router.post('/', (req, res) => {
-    const insertMessage = `INSERT INTO messages VALUES($1)`;
+    const insertMessage = `INSERT INTO messages VALUES($1, $2)`;
+    const msgCountQuery = `SELECT COUNT(*) FROM messages;`;
     console.log('req', req.body);
-    db.query(insertMessage, [req.body.message_text])
-      .then(data => {
-        res.json({ "status": "success" });
-      })
+
+    db.query(msgCountQuery).then((data) => {
+      console.log(
+        'LOGGING "parseInt(data.rows[0].count)":',
+        parseInt(data.rows[0].count)
+      );
+      const msgCount = parseInt(data.rows[0].count);
+      db.query(insertMessage, [msgCount + 1, req.body.message_text]).then(
+        (data) => {
+          res.json({ status: 'success' });
+        }
+      );
+    });
   });
   return router;
-}
+};


### PR DESCRIPTION
PostgreSQL database was giving an unexpected error when trying to add messages to their table -- it is refusing to automatically assign serial integer IDs.

For the time being, we've patched this by manually assigning IDs to each messaged by counting how many messages are currently in the table and incrementing by one.