### PR TITLE
Move submit button beside textarea element

### DIFF
--- a/client/src/components/ChatPanel.js
+++ b/client/src/components/ChatPanel.js
@@ -1,7 +1,7 @@
-import { useState, useEffect, Fragment } from "react";
+import { useState, useEffect, Fragment } from 'react';
 import axios from 'axios';
-import MessageForm from "./MessageForm";
-import MessageList from "./MessageList";
+import MessageForm from './MessageForm';
+import MessageList from './MessageList';
 import { BigHead } from '@bigheads/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { solid } from '@fortawesome/fontawesome-svg-core/import.macro';
@@ -14,33 +14,31 @@ export default function ChatPanel({ onSelect, userName }) {
   }, []);
 
   const getMessages = () => {
-    axios.get('http://localhost:8080/messages')
+    axios
+      .get('http://localhost:8080/messages')
       .then((res) => {
         setMessages(res.data);
       })
       .catch((err) => {
         console.log(err);
       });
-  }
+  };
 
   return (
     <section
       className="dashboard__panel bg-meringue"
       style={{ border: '1px solid black' }}
     >
-      <button
-        type='button'
-        className="flex mx-6"
-        onClick={onSelect}
-      >
+      <button type="button" className="flex mx-6" onClick={onSelect}>
         <FontAwesomeIcon icon={solid('expand')} className="h-7" />
       </button>
-      <h1 className="font-display text-4xl text-black text-center">Chat</h1>
-      <article className='flex flex-col items-center'>
+      <h1 className="mb-6 font-display text-4xl text-black text-center">
+        Chat
+      </h1>
+      <article className="flex flex-col items-center w-2/3 mx-auto">
         <MessageList messages={messages} />
         <MessageForm getMessages={getMessages} userName={userName} />
       </article>
     </section>
-
   );
-};
+}

--- a/client/src/components/Message.js
+++ b/client/src/components/Message.js
@@ -1,20 +1,21 @@
-import { BigHead } from "@bigheads/core";
+import { BigHead } from '@bigheads/core';
 
 export default function Message(props) {
-
   // const message = {
   //   user: 'LISA',
   //   body: 'Isn\'t StudeeCloud the best?!'
   // }
 
   return (
-    <article className="flex border-2 border-dark-gray rounded p-2 bg-gold h-30 my-2.5" style={{ width: 500 }}>
+    <article className="flex border-2 border-dark-gray rounded p-2 bg-gold h-30 w-full mb-2">
       <header>
         {/* <BigHead className="h-20 w-20" /> */}
-        <h2 className="m-1 font-body"><strong>{props.user}</strong></h2>
+        <h2 className="m-1 font-body">
+          <strong>{props.user}</strong>
+        </h2>
       </header>
 
-      <p className='m-auto font-body'>{props.body}</p>
+      <p className="m-auto font-body">{props.body}</p>
     </article>
   );
-};
+}

--- a/client/src/components/MessageForm.js
+++ b/client/src/components/MessageForm.js
@@ -12,7 +12,7 @@ export default function MessageForm({ getMessages, userName }) {
     axios
       .post('http://localhost:8080/messages', {
         message: message,
-        userName: userName,
+        userName: userName || 'NullUser',
       })
       .then((res) => {
         getMessages();
@@ -31,20 +31,23 @@ export default function MessageForm({ getMessages, userName }) {
         className="flex flex-col items-center"
         onSubmit={disableSubmit}
       >
-        <textarea
-          className="border-2 border-dark-gray p-2 rounded"
-          name="message"
-          placeholder="Talk to me..."
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          style={{ resize: 'none', width: 500, height: '2rem' }}
-        ></textarea>
-        <input
-          type="submit"
-          value="Message"
-          className="border-2 border-dark-gray p-2 rounded w-48 my-2.5"
-          onClick={handleSubmit}
-        />
+        <div className="flex">
+          <textarea
+            className="border-2 border-dark-gray py-2 px-1 mr-3 rounded"
+            name="message"
+            placeholder="Talk to me..."
+            rows={1}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            style={{ resize: 'none' }}
+          ></textarea>
+          <input
+            type="submit"
+            value="Send"
+            className="border-2 border-dark-gray p-2 rounded w-24 my-2.5"
+            onClick={handleSubmit}
+          />
+        </div>
       </form>
     </section>
   );

--- a/client/src/components/MessageForm.js
+++ b/client/src/components/MessageForm.js
@@ -4,14 +4,16 @@ import axios from 'axios';
 export default function MessageForm({ getMessages, userName }) {
   const [message, setMessage] = useState('');
 
-  const placeholder = 'Talk to me...';
   const disableSubmit = (e) => {
     e.preventDefault();
   };
 
   const handleSubmit = () => {
     axios
-      .post('http://localhost:8080/messages', { message: message, userName: userName })
+      .post('http://localhost:8080/messages', {
+        message: message,
+        userName: userName,
+      })
       .then((res) => {
         getMessages();
       })
@@ -19,7 +21,7 @@ export default function MessageForm({ getMessages, userName }) {
         console.log(err);
       });
     setMessage('');
-  }
+  };
 
   return (
     <section>
@@ -30,13 +32,12 @@ export default function MessageForm({ getMessages, userName }) {
         onSubmit={disableSubmit}
       >
         <textarea
-          type="text"
           className="border-2 border-dark-gray p-2 rounded"
-          name="text"
-          placeholder={placeholder}
+          name="message"
+          placeholder="Talk to me..."
           value={message}
           onChange={(e) => setMessage(e.target.value)}
-          style={{ width: 500, height: 75 }}
+          style={{ resize: 'none', width: 500, height: '2rem' }}
         ></textarea>
         <input
           type="submit"

--- a/client/src/components/MessageForm.js
+++ b/client/src/components/MessageForm.js
@@ -24,16 +24,16 @@ export default function MessageForm({ getMessages, userName }) {
   };
 
   return (
-    <section>
+    <section className="w-full">
       <form
         method="post"
         action="/messages"
         className="flex flex-col items-center"
         onSubmit={disableSubmit}
       >
-        <div className="flex">
+        <div className="flex w-full">
           <textarea
-            className="border-2 border-dark-gray py-2 px-1 mr-3 rounded"
+            className="border-2 border-dark-gray py-2 px-3 mr-2 rounded w-full"
             name="message"
             placeholder="Talk to me..."
             rows={1}
@@ -44,7 +44,7 @@ export default function MessageForm({ getMessages, userName }) {
           <input
             type="submit"
             value="Send"
-            className="border-2 border-dark-gray p-2 rounded w-24 my-2.5"
+            className="w-24 p-2 border-2 border-dark-gray rounded"
             onClick={handleSubmit}
           />
         </div>

--- a/client/src/components/MessageList.js
+++ b/client/src/components/MessageList.js
@@ -1,27 +1,22 @@
-import Message from "./Message";
-
+import Message from './Message';
 
 /**
- * 
- * @param {Object} messages includes two keys: {String} message and {String} sender 
+ *
+ * @param {Object} messages includes two keys: {String} message and {String} sender
  * @returns All Message components
  */
 export default function MessageList({ messages }) {
-
   return (
     <>
-      {
-        messages.map((message, i) => {
-          return (
-            <Message
-              key={i}
-              user={message.sender.toUpperCase()}
-              body={message.message}
-            />
-          )
-        }
-        )
-      }
+      {messages.map((message, i) => {
+        return (
+          <Message
+            key={i}
+            user={message.sender.toUpperCase()}
+            body={message.message}
+          />
+        );
+      })}
     </>
-  )
+  );
 }


### PR DESCRIPTION
Made several small styling adjustments with the aim of moving the submit button beside the `textarea` element. Opted to simplify things by setting CSS property `resize: none` and set the `textarea` height to one line of text, on the assumption that the majority of user messages will be short. Also set a relative width for the entire chat panel so the chat panel automatically looks good in focused view 😄 

Looks like:
![Screen Shot 2022-05-22 at 1 15 49 AM](https://user-images.githubusercontent.com/5186441/169680016-c32e80c5-b6ee-4436-ac7d-74861d1aa4cc.png)

