### PR TITLE
Optimize positioning of panel focus buttons

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -15,10 +15,8 @@
 .dashboard__panel {
   width: 100%;
   height: 100%;
-  text-align: center;
   font-size: 1rem;
   cursor: pointer;
-  /* padding: 1.2rem; */
 }
 
 .dashboard__panel-header {

--- a/client/src/components/ChatPanel.js
+++ b/client/src/components/ChatPanel.js
@@ -25,21 +25,16 @@ export default function ChatPanel({ onSelect, userName }) {
   };
 
   return (
-    <section
-      className="dashboard__panel relative bg-meringue"
-      style={{ border: '1px solid black' }}
-    >
+    <section className="dashboard__panel relative border bg-meringue">
       <button
         type="button"
-        className="mt-3 absolute"
-        style={{ width: '93%' }}
+        className="absolute"
+        style={{ top: '3.5%', right: '2%' }}
         onClick={onSelect}
       >
         <FontAwesomeIcon icon={solid('expand')} className="h-7" />
       </button>
-      <h1 className="mt-3 mb-5 font-display text-4xl text-black text-center">
-        Chat
-      </h1>
+      <h1 className="mt-3 mb-5 font-display text-4xl text-center">Chat</h1>
       <article className="flex flex-col items-center w-2/3 mx-auto">
         <MessageList messages={messages} />
         <MessageForm getMessages={getMessages} userName={userName} />

--- a/client/src/components/DiscoSound.js
+++ b/client/src/components/DiscoSound.js
@@ -40,7 +40,7 @@ export default function DiscoSound() {
   return (
     <section className="flex flex-row justify-around">
       <div>
-        <h1 className="font-body text-2xl text-black text-center">Disco </h1>
+        <h1 className="font-body text-2xl text-center">Disco </h1>
       </div>
       <div>
         <button

--- a/client/src/components/GhibliSound.js
+++ b/client/src/components/GhibliSound.js
@@ -19,7 +19,7 @@ export default function GhibliSound() {
   return (
     <section className="flex flex-row justify-around">
       <div>
-        <h1 className="font-body text-2xl text-black text-center">Ghibli </h1>
+        <h1 className="font-body text-2xl text-center">Ghibli </h1>
       </div>
       <div>
         <button

--- a/client/src/components/RainSound.js
+++ b/client/src/components/RainSound.js
@@ -19,7 +19,7 @@ export default function RainSound() {
   return (
     <section className="flex flex-row justify-around">
       <div>
-        <h1 className="font-body text-2xl text-black text-center">Rainy</h1>
+        <h1 className="font-body text-2xl text-center">Rainy</h1>
       </div>
       <div>
         <button

--- a/client/src/components/SoundPanel.js
+++ b/client/src/components/SoundPanel.js
@@ -11,20 +11,17 @@ import GhibliSound from './GhibliSound';
 
 export default function TitlePanel({ onSelect }) {
   return (
-    <section
-      className="dashboard__panel relative bg-meringue"
-      style={{ border: '1px solid black' }}
-    >
+    <section className="dashboard__panel relative border bg-meringue">
       <button
         type="button"
-        className="mt-3 absolute"
-        style={{ width: '93%' }}
+        className="absolute"
+        style={{ top: '3.5%', right: '2%' }}
         onClick={onSelect}
       >
         <FontAwesomeIcon icon={solid('expand')} className="h-7" />
       </button>
 
-      <h1 className="mt-3 mb-5 font-display text-4xl text-black text-center">
+      <h1 className="mt-3 mb-5 font-display text-4xl text-center">
         Soundboard
       </h1>
       <h2 className="font-body text-lg text-center">SFX</h2>

--- a/client/src/components/TitlePanel.js
+++ b/client/src/components/TitlePanel.js
@@ -12,30 +12,31 @@ export default function TitlePanel({ onSelect, roomName }) {
   // onSelect:Function
 
   return (
-    <section
-      className="dashboard__panel relative bg-gold"
-      style={{ border: '1px solid black' }}
-    >
+    <section className="dashboard__panel relative border bg-gold">
       <button
         type="button"
-        className="mt-3 absolute"
-        style={{ width: '93%' }}
+        className="absolute"
+        style={{ top: '3.5%', right: '2%' }}
         onClick={onSelect}
       >
         <FontAwesomeIcon icon={solid('expand')} className="h-7" />
       </button>
-      <h1 className="mt-3 mb-5 font-display text-4xl text-black text-center">
+
+      <h1 className="mt-3 mb-5 font-display text-4xl text-center">
         StudeeCloud
       </h1>
+
       <h2 className="font-header text-3xl text-center">
         Collaborative
         <br />
         Study Environment
       </h2>
+
       <h3 className="font-body text-2xl">
         <strong>Room: </strong>
         {roomName}
       </h3>
+
       <PomodoroTimer />
     </section>
   );

--- a/client/src/components/VideoPanel.js
+++ b/client/src/components/VideoPanel.js
@@ -14,20 +14,16 @@ export default function VideoPanel({
   // TODO -- Update this so the Big Heads aren't regenerated on each click to this panel
 
   return (
-    <section
-      className="dashboard__panel relative bg-meringue"
-      style={{ border: '1px solid black' }}
-      // onClick={onSelect}
-    >
+    <section className="dashboard__panel relative border bg-meringue">
       <button
         type="button"
-        className="mt-3 absolute"
-        style={{ width: '93%' }}
+        className="absolute"
+        style={{ top: '3.5%', right: '2%' }}
         onClick={onSelect}
       >
         <FontAwesomeIcon icon={solid('expand')} className="h-7" />
       </button>
-      <h1 className="mt-3 mb-5 font-display mb-6 text-4xl text-black text-center">
+      <h1 className="mt-3 mb-5 font-display mb-6 text-4xl text-center">
         Squad
       </h1>
 


### PR DESCRIPTION
Previously the buttons were positioned using a hacked-together solution. I updated this to use the CSS properties `top` & `right` as I should have initially done.

I also deleted some unnecessary Tailwind classes -- `text-center` and `text-black` that were either not doing anything, or were getting in the way.